### PR TITLE
Fix repeat options bug for PlacesAutocompleteField

### DIFF
--- a/src/components/ui/PlacesAutocompleteField.tsx
+++ b/src/components/ui/PlacesAutocompleteField.tsx
@@ -47,9 +47,11 @@ export const PlacesAutocompleteField: React.FC<Props> = ({
   };
 
   const findByMainText = useCallback(
-    (mainText: string) => {
+    (address: string) => {
       return data.find(
-        (suggestion) => suggestion.structured_formatting.main_text == mainText,
+        (suggestion) =>
+          address.includes(suggestion.structured_formatting.main_text) &&
+          address.includes(suggestion.structured_formatting.secondary_text),
       );
     },
     [data],
@@ -73,7 +75,8 @@ export const PlacesAutocompleteField: React.FC<Props> = ({
       value={value}
       onChange={setValue}
       data={data.map(
-        (suggestion) => suggestion.structured_formatting.main_text,
+        (suggestion) =>
+          `${suggestion.structured_formatting.main_text}, ${suggestion.structured_formatting.secondary_text}`,
       )}
       disabled={!places}
       onOptionSubmit={(value) => onSelectSuggestion?.(findByMainText(value))}

--- a/src/components/ui/PlacesAutocompleteField.tsx
+++ b/src/components/ui/PlacesAutocompleteField.tsx
@@ -50,8 +50,8 @@ export const PlacesAutocompleteField: React.FC<Props> = ({
     (address: string) => {
       return data.find(
         (suggestion) =>
-          address.includes(suggestion.structured_formatting.main_text) &&
-          address.includes(suggestion.structured_formatting.secondary_text),
+          address ===
+          `${suggestion.structured_formatting.main_text}, ${suggestion.structured_formatting.secondary_text}`,
       );
     },
     [data],


### PR DESCRIPTION
The `main_text` was used as the data in mantine's Autocomplete component, but `main_text` is not unique which caused runtime error when there are duplicates. This has been fixed by using "`main_text`, `secondary_text`" as the value.

![image](https://github.com/user-attachments/assets/1563ecb7-caa9-4d5b-a963-4c7efc612627)

Fixes #54 