### PR TITLE
Fix firefox image bug

### DIFF
--- a/src/components/reviewMedia/MediaPreview.tsx
+++ b/src/components/reviewMedia/MediaPreview.tsx
@@ -43,6 +43,7 @@ export const MediaPreview: React.FC<Props> = ({
     <Image
       loading="lazy"
       h={height}
+      w="auto"
       maw={width}
       src={mediaUrl}
       onClick={onClick}


### PR DESCRIPTION
Firefox and other browsers deal with `height: auto` css differently. Closes #84